### PR TITLE
Fixed sepBy1 to not require a trailing separator

### DIFF
--- a/core/src/main/scala/atto/parser/Combinator.scala
+++ b/core/src/main/scala/atto/parser/Combinator.scala
@@ -213,7 +213,7 @@ trait Combinator extends Combinator0 {
     cons(p, ((s ~> sepBy1(p,s)) | ok(Nil))) | ok(Nil) as ("sepBy(" + p + "," + s + ")")
 
   def sepBy1[A](p: Parser[A], s: Parser[Any]): Parser[List[A]] = {
-    lazy val scan : Parser[List[A]] = cons(p, s ~> scan) | ok(Nil)
+    lazy val scan : Parser[List[A]] = cons(p, s ~> scan | ok(Nil))
     scan as ("sepBy1(" + p + "," + s + ")")
   }
 


### PR DESCRIPTION
sepBy(letter, char(',')).parseOnly("a,b,c") should result in Done(, List(a, b, c)) not Done(c, List(a, b)).

The ok(Nil) needs to be inside the cons() and part of the s ~> scan parser.  That's the way the Haskell attoparsec sepBy1 is implemented.
