### PR TITLE
Speed up stringLiteral parsing by 10x on alpha numeric strings

### DIFF
--- a/core/src/main/scala/atto/parser/Text.scala
+++ b/core/src/main/scala/atto/parser/Text.scala
@@ -147,7 +147,7 @@ trait Text {
       string("\\u") ~> count(4, hexDigit).map(ds => Integer.parseInt(ds.mkString, 16).toChar)
 
     // Quoted strings
-    char('"') ~> many(esc | unicode | nesc).map(_.mkString) <~ char('"')
+    char('"') ~> many(nesc | esc | unicode ).map(_.mkString) <~ char('"')
 
   } named "stringLiteral"
 


### PR DESCRIPTION
By checking escaped characters first the stringLiteral parser was about 10 times slower than if you match on unescaped characters first. Of course this is a best case improvement, but I think it's reasonable to run the unescaped parser first in most cases.
