### PR TITLE
manyNM and dependencies

### DIFF
--- a/core/src/test/scala/atto/CombinatorTest.scala
+++ b/core/src/test/scala/atto/CombinatorTest.scala
@@ -185,18 +185,18 @@ object CombinatorTest extends Properties("Combinator") {
     (n >= 0 && m >= n) ==> {
       val result = manyNM(n, m, anyChar).parseOnly(s)
       if (s.length >= n) {
-        val parseLen = m min s.length
+        val expectedLen = m min s.length
         val left = s.takeRight(if (s.length > m) s.length - m else 0)
          result match {
-          case ParseResult.Done(x, y) =>
-            (parseLen == y.length) :| s"expected $parseLen characters but got ${y.length}" &&
-              (x == left) :| s"remainder expected '$left', got '$x' in $result"
-          case _ => (s.length < n) :| "parse failed"
+          case ParseResult.Done(in, r) =>
+            (expectedLen == r.length) :| s"expected $expectedLen characters but got ${r.length}" &&
+              (in == left) :| s"remainder expected '$left', got '$in' in $result"
+          case _ => false
         }
       } else // s.length < n
         result match {
-        case ParseResult.Fail(x, y, _) =>
-          (x == s) :| "shouldn't consume any input"
+        case ParseResult.Fail(in, _, _) =>
+          (in == s) :| "shouldn't consume any input"
         case _ => false
       }
     }


### PR DESCRIPTION
added `upToN` and `manyNM` + tests.  They require() n >= 0, m >= n.

changed `manyN` from foldLeft to recursive — could use a sanity check, will the trampolining in `cons` be enough to keep it from blowing the stack?  Updated the test to try larger numbers (#7).  

Because no longer using `Range` in `manyN`, `manyN` needs to require `n >= 0`; same with `skipManyN` which calls `manyN`.  Updated both tests.