### PR TITLE
Add parser that returns the current offset

### DIFF
--- a/core/src/main/scala/atto/parser/Combinator.scala
+++ b/core/src/main/scala/atto/parser/Combinator.scala
@@ -110,6 +110,14 @@ trait Combinator0 {
         suspend(ks(st0,st0.input.drop(st0.pos)))
     }
 
+  /* Parser that produces the current offset in the input. */
+  val pos: Parser[Int] =
+    new Parser[Int] {
+      override def toString = "pos"
+      def apply[R](st0: State, kf: Failure[R], ks: Success[Int,R]): TResult[R] =
+        suspend(ks(st0,st0.pos))
+    }
+
   def endOfChunk: Parser[Boolean] =
     new Parser[Boolean] {
       override def toString = "endOfChunk"

--- a/core/src/test/scala/atto/CombinatorTest.scala
+++ b/core/src/test/scala/atto/CombinatorTest.scala
@@ -35,6 +35,20 @@ object CombinatorTest extends Properties("Combinator") {
     }
   }
 
+  property("pos") = forAll { (s: String) =>
+    (s.length > 0) ==> {
+      val simpleParser = for {
+        _ <- take(s.length - 1)
+        p <- pos
+      } yield p
+
+      simpleParser.parseOnly(s) match {
+        case ParseResult.Done(_, position) => position == s.length - 1
+        case _ => false
+      }
+    }
+  }
+
   property("advance") = forAll { (s: String, x: Int) =>
     (x >= 0) ==> {
       advance(x).parseOnly(s) match {


### PR DESCRIPTION
This parser returns `State.pos` which is the absolute offset from the start of input. Useful for parsing tokens with source locations, for instance.

```scala
case class Pos[A](a: A, offset: Int, length: Int)

def withPos[A](p: Parser[A]): Parser[Pos[A]] =
  (pos |@| p |@| pos)((s, a, e) => Pos(a, s, e - s)) named s"withPos($p)"

val notDigit = satisfy(c => !c.isDigit)

val p = (notDigit.many ~> withPos(int)).many

scala> p.parse("The secret number is '123'").feed(" said the 456 cow.").done
res0: atto.ParseResult[List[Pos[Int]]] = Done( cow.,List(Pos(123,22,3), Pos(456,36,3)))
```