### PR TITLE
Fixed optElem causing OutOfMemoryError when combined with many

### DIFF
--- a/core/src/main/scala/atto/parser/Character.scala
+++ b/core/src/main/scala/atto/parser/Character.scala
@@ -89,7 +89,7 @@ trait Character {
   /** `elem` + `map` in a single operation. */
   def optElem[A](p: Char => Option[A]): Parser[A] =
     ensure(1) flatMap { s =>
-      p(s.head).cata(a => advance(s.tail.length) ~> ok(a), err("optElem(...)"))
+      p(s.head).cata(a => advance(1) ~> ok(a), err("optElem(...)"))
     } named "optElem(...)"
 
   /** Parser that skips a `Char` if it satisfies predicate `p`. */

--- a/core/src/test/scala/atto/CharacterTest.scala
+++ b/core/src/test/scala/atto/CharacterTest.scala
@@ -53,5 +53,10 @@ object CharacterTest extends Properties("Character") {
       Some(c).filter(_ < d)
   }
 
+  property("optElem + many") = forAll { (s: String, c: Char) =>
+    val p = many(optElem(ch => Some(ch).filter(_ < c)))
+    p.parseOnly(s).option == Some(s.toList.takeWhile(_ < c))
+  }
+
 }
 


### PR DESCRIPTION
This was happening:

```scala
scala> many(optElem(c => c.some.filter(_.isLetter))).parseOnly("something")
java.lang.OutOfMemoryError: Java heap space
```

The problem is in the ```advance(s.tail.length)``` call inside ```optElem```, where an ```advance(1)``` should be expected.