### PR TITLE
Upgrade atto-core to scalaz 7.2.4 and scalacheck 1.13.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,8 +7,8 @@ lazy val buildSettings = Seq(
 		("MIT", url("http://opensource.org/licenses/MIT")),
 		("BSD New", url("http://opensource.org/licenses/BSD-3-Clause"))
 	),
-	scalaVersion := "2.11.7",
-	crossScalaVersions := Seq("2.10.5", scalaVersion.value)
+	scalaVersion := "2.11.8",
+	crossScalaVersions := Seq("2.10.6", scalaVersion.value)
 )
 
 lazy val commonSettings = Seq(
@@ -90,7 +90,7 @@ lazy val core = project.in(file("core"))
   .settings(name := "atto-core")
   .settings(
   	libraryDependencies ++= Seq(
-      "org.scalaz"     %% "scalaz-core" % "7.2.1",
+      "org.scalaz"     %% "scalaz-core" % "7.2.4",
       "org.scalacheck" %% "scalacheck"  % "1.13.1" % "test"
 		)
 	)

--- a/build.sbt
+++ b/build.sbt
@@ -90,8 +90,8 @@ lazy val core = project.in(file("core"))
   .settings(name := "atto-core")
   .settings(
   	libraryDependencies ++= Seq(
-		  "org.scalaz"     %% "scalaz-core" % "7.1.0",
-		  "org.scalacheck" %% "scalacheck"  % "1.11.3" % "test"
+      "org.scalaz"     %% "scalaz-core" % "7.2.1",
+      "org.scalacheck" %% "scalacheck"  % "1.13.1" % "test"
 		)
 	)
 	.settings(initialCommands := "import scalaz._, Scalaz._, atto._, Atto._")

--- a/core/src/main/scala/atto/parser/Text.scala
+++ b/core/src/main/scala/atto/parser/Text.scala
@@ -21,11 +21,11 @@ trait Text {
 
   /** Parser that returns a string of characters matched by `p`. */
   def stringOf(p: Parser[Char]): Parser[String] =
-    many(p).map(cs => new String(cs.toArray)) named "stringOf(" + p + ")"
+    many(p).map(cs => new String(cs.toList.toArray)) named "stringOf(" + p + ")"
 
   /** Parser that returns a non-empty string of characters matched by `p`. */
   def stringOf1(p: Parser[Char]): Parser[String] =
-    many1(p).map(cs => new String(cs.list.toArray)) named "stringOf1(" + p + ")"
+    many1(p).map(cs => new String(cs.list.toList.toArray)) named "stringOf1(" + p + ")"
 
   def takeWith(n: Int, p: String => Boolean, what: => String = "takeWith(...)"): Parser[String] =
     ensure(n) flatMap { s =>
@@ -156,10 +156,10 @@ trait Text {
 
     // Unicode escaped characters
     val unicode: Parser[Char] =
-      string("\\u") ~> count(4, hexDigit).map(ds => Integer.parseInt(new String(ds.toArray), 16).toChar)
+      string("\\u") ~> count(4, hexDigit).map(ds => Integer.parseInt(new String(ds.toList.toArray), 16).toChar)
 
     // Quoted strings
-    char('"') ~> many(nesc | esc | unicode ).map(cs => new String(cs.toArray)) <~ char('"')
+    char('"') ~> many(nesc | esc | unicode ).map(cs => new String(cs.toList.toArray)) <~ char('"')
 
   } named "stringLiteral"
 

--- a/core/src/main/scala/atto/syntax/ParserOps.scala
+++ b/core/src/main/scala/atto/syntax/ParserOps.scala
@@ -2,10 +2,11 @@ package atto
 package syntax
 
 import java.lang.String
-import scala.{ StringContext, PartialFunction }
+
+import scala.{PartialFunction, StringContext}
 import scala.language.implicitConversions
 import scalaz.syntax.Ops
-import scalaz.{ \/, NonEmptyList }
+import scalaz.{IList, NonEmptyList, \/}
 import atto.parser._
 
 trait ParserOps[A] extends Ops[Parser[A]] {
@@ -65,7 +66,7 @@ trait ParserOps[A] extends Ops[Parser[A]] {
   def collect[B](pf: PartialFunction[A,B]): Parser[B] =
     combinator.collect(self, pf)
 
-  def sepBy[B](s: Parser[B]): Parser[List[A]] =
+  def sepBy[B](s: Parser[B]): Parser[IList[A]] =
     combinator.sepBy(self, s)
 
   def sepBy1[B](s: Parser[B]): Parser[NonEmptyList[A]] =
@@ -83,13 +84,13 @@ trait ParserOps[A] extends Ops[Parser[A]] {
   def skipManyN(n: Int): Parser[Unit] =
     combinator.skipManyN(n, self)
 
-  def many: Parser[List[A]] =
+  def many: Parser[IList[A]] =
     combinator.many(self)
 
   def many1: Parser[NonEmptyList[A]] =
     combinator.many1(self)
 
-  def manyN(n: Int): Parser[List[A]] =
+  def manyN(n: Int): Parser[IList[A]] =
     combinator.manyN(n, self)
 }
 

--- a/core/src/test/scala/atto/CharacterTest.scala
+++ b/core/src/test/scala/atto/CharacterTest.scala
@@ -55,7 +55,7 @@ object CharacterTest extends Properties("Character") {
 
   property("optElem + many") = forAll { (s: String, c: Char) =>
     val p = many(optElem(ch => Some(ch).filter(_ < c)))
-    p.parseOnly(s).option == Some(s.toList.takeWhile(_ < c))
+    p.parseOnly(s).option.map(_.toList) == Some(s.toList.takeWhile(_ < c))
   }
 
 }

--- a/core/src/test/scala/atto/CombinatorTest.scala
+++ b/core/src/test/scala/atto/CombinatorTest.scala
@@ -144,14 +144,14 @@ object CombinatorTest extends Properties("Combinator") {
   }
 
   property("cons") = forAll { (c: Char, s: String) =>
-    lazy val p: Parser[NonEmptyList[Char]] = cons(anyChar, orElse(p.map(_.list), ok(Nil)))
+    lazy val p: Parser[NonEmptyList[Char]] = cons(anyChar, orElse(p.map(_.list), ok(INil())))
     p.parseOnly(c + s).option == Some(NonEmptyList(c, s.toList: _*))
   }
 
   // phrase
 
   property("many") = forAll { (s: String) =>
-    many(anyChar).parseOnly(s).option == Some(s.toList)
+    many(anyChar).parseOnly(s).option.map(_.toList) == Some(s.toList)
   }
 
   property("many1") = forAll { (s: String) =>
@@ -161,14 +161,14 @@ object CombinatorTest extends Properties("Combinator") {
 
   property("manyN") = forAll { (s: String, n0: Int) =>
     val n = if (s.isEmpty) 0 else (n0.abs % s.length)
-    manyN(n, anyChar).parseOnly(s).option ==
+    manyN(n, anyChar).parseOnly(s).option.map(_.toList) ==
       Some(s.take(n).toList)
   }
 
   property("manyUntil") = forAll { (s: String) =>
     (s.nonEmpty && s.indexOf("x") == -1) ==> {
       val r = manyUntil(string(s), char('x')).parseOnly(s * 3 + "xyz").done
-      r == ParseResult.Done("yz", List(s, s, s))
+      r == ParseResult.Done("yz", IList(s, s, s))
     }
   }
 
@@ -191,7 +191,7 @@ object CombinatorTest extends Properties("Combinator") {
     val sep = s + c
     !(sep.exists(_.isDigit)) ==> {
       val p = sepBy(int, string(sep))
-      p.parseOnly(ns.mkString(sep)) match {
+      p.parseOnly(ns.mkString(sep)).map(_.toList) match {
         case ParseResult.Done("", `ns`) => true
         case _ => false
       }
@@ -203,7 +203,7 @@ object CombinatorTest extends Properties("Combinator") {
     val sep = s + c
     !(sep.exists(_.isDigit)) ==> {
       val p = sepBy1(int, string(sep))
-      p.parseOnly(ns.list.mkString(sep)) match {
+      p.parseOnly(ns.list.toList.mkString(sep)) match {
         case ParseResult.Done("", `ns`) => true
         case _ => false
       }
@@ -240,7 +240,7 @@ object CombinatorTest extends Properties("Combinator") {
   property("count") = forAll { (c: Char, n0: Int) =>
     val n = (n0.abs % 10) + 1
     val s = c.toString * 20
-    count(n, char(c)).parseOnly(s) == ParseResult.Done(s drop n, List.fill(n)(c))
+    count(n, char(c)).parseOnly(s) == ParseResult.Done(s drop n, IList.fill(n)(c))
   }
 
 }

--- a/core/src/test/scala/atto/IncrementalTest.scala
+++ b/core/src/test/scala/atto/IncrementalTest.scala
@@ -15,7 +15,7 @@ object IncrementalTest extends Properties("Incremental") {
       val p = sepBy(int, string(sep))
       val s = ns.mkString(sep)
       val c = s.grouped(1 max (n % s.length).abs).toList
-      (p.parse("") /: c)(_ feed _).done match {
+      (p.parse("") /: c)(_ feed _).done.map(_.toList) match {
         case ParseResult.Done("", `ns`) => true
         case _ => false
       }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.11


### PR DESCRIPTION
WIP upgrade to scalaz 7.2.4. So far I just upgraded `atto-core` - thought it'd be good to discuss `IList` vs `List` before proceeding:

I changed `List[A]` to `IList[A]` e.g.: `def many[A](p: => Parser[A]): Parser[IList[A]]`. 
Since these are breaking changes, I can imagine that you prefer to keep methods like this to return `List[A]` instead. Happy to change it back.
