### PR TITLE
Remove unnecessary constraints.

### DIFF
--- a/core/src/main/scala/atto/parser/Text.scala
+++ b/core/src/main/scala/atto/parser/Text.scala
@@ -15,12 +15,14 @@ trait Text {
   import character._
 
   /** Parser that returns a string of characters matched by `p`. */
-  def stringOf[F[_]: NonEmptyListy](p: Parser[Char]): Parser[String] =
+  def stringOf(p: Parser[Char]): Parser[String] =
     many(p).map(cs => new String(cs.toArray)) named "stringOf(" + p + ")"
 
   /** Parser that returns a non-empty string of characters matched by `p`. */
-  def stringOf1[F[_]](p: Parser[Char])(implicit N: NonEmptyListy[F]): Parser[String] =
+  def stringOf1(p: Parser[Char]): Parser[String] = {
+    implicit val N = stdlib.StdlibNonEmptyListy
     many1(p).map(cs => new String(N.toList(cs).toArray)) named "stringOf1(" + p + ")"
+  }
 
   def takeWith(n: Int, p: String => Boolean, what: => String = "takeWith(...)"): Parser[String] =
     ensure(n) flatMap { s =>
@@ -132,7 +134,7 @@ trait Text {
   }
 
   /** Quoted strings with control and unicode escapes, Java/JSON style. **/
-  def stringLiteral[F[_]: NonEmptyListy]: Parser[String] = {
+  def stringLiteral: Parser[String] = {
 
     // Unescaped characters
     val nesc: Parser[Char] =
@@ -200,4 +202,3 @@ trait Text {
     bracket(string("(|"), q, string("|)")).named(s"banana(${q.toString})")
   }
 }
-

--- a/core/src/main/scala/atto/syntax/ParserOps.scala
+++ b/core/src/main/scala/atto/syntax/ParserOps.scala
@@ -66,7 +66,7 @@ trait ParserOps[A] {
   def collect[B](pf: PartialFunction[A,B]): Parser[B] =
     combinator.collect(self, pf)
 
-  def sepBy[F[_]: NonEmptyListy, B](s: Parser[B]): Parser[List[A]] =
+  def sepBy[B](s: Parser[B]): Parser[List[A]] =
     combinator.sepBy(self, s)
 
   def sepBy1[F[_]: NonEmptyListy, B](s: Parser[B]): Parser[F[A]] =
@@ -75,22 +75,22 @@ trait ParserOps[A] {
   def attempt: Parser[A] =
     combinator.attempt(self)
 
-  def skipMany[F[_]: NonEmptyListy]: Parser[Unit] =
+  def skipMany: Parser[Unit] =
     combinator.skipMany(self)
 
-  def skipMany1[F[_]: NonEmptyListy]: Parser[Unit] =
+  def skipMany1: Parser[Unit] =
     combinator.skipMany1(self)
 
-  def skipManyN[F[_]: NonEmptyListy](n: Int): Parser[Unit] =
+  def skipManyN(n: Int): Parser[Unit] =
     combinator.skipManyN(n, self)
 
-  def many[F[_]: NonEmptyListy]: Parser[List[A]] =
+  def many: Parser[List[A]] =
     combinator.many(self)
 
   def many1[F[_]: NonEmptyListy]: Parser[F[A]] =
     combinator.many1(self)
 
-  def manyN[F[_]: NonEmptyListy](n: Int): Parser[List[A]] =
+  def manyN(n: Int): Parser[List[A]] =
     combinator.manyN(n, self)
 }
 


### PR DESCRIPTION
Some combinators like `sepBy1` require `NonEmptyListy[F]` and return `F[A]`. But combinators that don't mention `F` in the return type (but rely on other combinators that do require an instance) can simply use the standard library instance.

Resolves #30 
Resolves #34