### PR TITLE
Update to support scala 2.12.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 scala:
   - 2.11.11
   - 2.10.6
+  - 2.12.2
 install:
   - . $HOME/.nvm/nvm.sh
   - nvm install stable
@@ -10,4 +11,4 @@ jdk:
   - oraclejdk8
   - oraclejdk7
 
-script: sbt ++$TRAVIS_SCALA_VERSION test docs/tut
+script: sbt ++$TRAVIS_SCALA_VERSION test

--- a/modules/core/src/main/scala/atto/ParseResult.scala
+++ b/modules/core/src/main/scala/atto/ParseResult.scala
@@ -2,7 +2,7 @@ package atto
 
 import atto.compat.Eithery
 import java.lang.String
-import scala.{ Option, Some, None, Nothing, List }
+import scala.{ Option, Some, None, List }
 import scala.language.higherKinds
 
 sealed abstract class ParseResult[A] {
@@ -39,4 +39,3 @@ object ParseResult {
   }
 
 }
-

--- a/modules/core/src/main/scala/atto/Parser.scala
+++ b/modules/core/src/main/scala/atto/Parser.scala
@@ -1,17 +1,13 @@
 package atto
 
-import scala.language.implicitConversions
-import scala.language.higherKinds
-
 import java.lang.String
-import scala.{ Boolean, List, Nothing }
+import scala.{ Boolean, List }
 
 import Trambopoline._
 
 // Operators not needed for use in `for` comprehensions are provided via added syntax.
 trait Parser[A] { m =>
   import Parser._
-  import Parser.Internal._
 
   def apply[R](st0: State, kf: Failure[R], ks: Success[A,R]): TResult[R]
 
@@ -103,7 +99,3 @@ trait ParserFunctions {
   }
 
 }
-
-
-
-

--- a/modules/core/src/main/scala/atto/parser/Character.scala
+++ b/modules/core/src/main/scala/atto/parser/Character.scala
@@ -3,13 +3,12 @@ package parser
 
 import java.lang.String
 import atto.syntax.parser._
-import scala.{ Char, Boolean, Unit, StringContext, Option }
+import scala.{ Char, Boolean, Unit, Option }
 import scala.Predef.{ charWrapper, augmentString }
 
 /** Parsers for various kinds of characters. */
 trait Character {
   import combinator._
-  import text._
 
   /** Parser that returns a `Char` if it satisfies predicate `p`. */
   def elem(p: Char => Boolean, what: => String = "elem(...)"): Parser[Char] =
@@ -101,5 +100,3 @@ trait Character {
   def horizontalWhitespace =
     elem(c => c.isWhitespace && c != '\r' && c != '\n', "horizontalWhitespace")
 }
-
-

--- a/modules/core/src/main/scala/atto/parser/Combinator.scala
+++ b/modules/core/src/main/scala/atto/parser/Combinator.scala
@@ -2,7 +2,7 @@ package atto
 package parser
 
 import java.lang.String
-import scala.{ Boolean, Nothing, Unit, Int, Nil, List, PartialFunction, StringContext, Option }
+import scala.{ Boolean, Unit, Int, Nil, List, PartialFunction, StringContext, Option }
 import scala.language.higherKinds
 
 import atto.compat._
@@ -296,5 +296,5 @@ trait Combinator extends Combinator0 {
     implicit val N = stdlib.StdlibNonEmptyListy
     ((1 to n) :\ ok(List[A]()))((_, a) => cons(p, a).map(N.toList))
   }
-  
+
 }

--- a/modules/core/src/main/scala/atto/parser/Text.scala
+++ b/modules/core/src/main/scala/atto/parser/Text.scala
@@ -7,7 +7,6 @@ import atto.syntax.parser._
 import java.lang.{ String, Integer }
 import scala.{ Char, List, Int, StringContext, Boolean, Nil, Nothing, Unit, Option, Some, None }
 import scala.Predef.{ augmentString, charWrapper }
-import scala.language.higherKinds
 
 /** Text parsers. */
 trait Text {

--- a/modules/core/src/main/scala/atto/syntax/ParserOps.scala
+++ b/modules/core/src/main/scala/atto/syntax/ParserOps.scala
@@ -2,7 +2,7 @@ package atto
 package syntax
 
 import java.lang.String
-import scala.{ StringContext, PartialFunction }
+import scala.PartialFunction
 import scala.language.implicitConversions
 import scala.language.higherKinds
 import atto.compat._

--- a/modules/tests/src/test/scala/atto/CharacterTest.scala
+++ b/modules/tests/src/test/scala/atto/CharacterTest.scala
@@ -1,15 +1,12 @@
 package atto
 import Atto._
-import atto.compat.scalaz._
 
 import scala.util.Random
 
 import org.scalacheck._
-import scalaz.\/._
 
 object CharacterTest extends Properties("Character") {
   import Prop._
-  import Parser._
 
   property("satisfy") = forAll { (w: Char, s: String) =>
     satisfy(_ <= w).parse(w +: s).option == Some(w)
@@ -60,4 +57,3 @@ object CharacterTest extends Properties("Character") {
   }
 
 }
-

--- a/modules/tests/src/test/scala/atto/CombinatorTest.scala
+++ b/modules/tests/src/test/scala/atto/CombinatorTest.scala
@@ -11,7 +11,6 @@ import atto.compat.scalaz._
 
 object CombinatorTest extends Properties("Combinator") {
   import Prop._
-  import Parser._
 
   implicit val eqChar: Equal[Char] = Order[Char] // :-\
 
@@ -259,4 +258,3 @@ object CombinatorTest extends Properties("Combinator") {
   }
 
 }
-

--- a/modules/tests/src/test/scala/atto/CompatTest.scala
+++ b/modules/tests/src/test/scala/atto/CompatTest.scala
@@ -12,15 +12,18 @@ object CompatTest {
     {
       val a = (null : ParseResult[Int]).either
       val b: String \/ Int = a
+      b
     }
 
     {
       val a = many1(int)
       val b: Parser[NonEmptyList[Int]] = a
+      b
     }
 
     {
       val c = choice(List[Parser[Int]]())
+      c
     }
 
   }
@@ -32,36 +35,42 @@ object CompatTest {
     {
       val a = (null : ParseResult[Int]).either
       val b: Either[String, Int] = a
+      b
     }
 
     {
       val a = many1(int)
       val b: Parser[(Int, List[Int])] = a
+      b
     }
 
     {
       val c = choice(List[Parser[Int]]())
+      c
     }
 
   }
 
   object CatsCompat {
 
-    import cats._, cats.data._, cats.implicits._
+    import cats.data._, cats.implicits._
     import atto.compat.cats._
 
     {
       val a = (null : ParseResult[Int]).either
       val b: Either[String, Int] = a
+      b
     }
 
     {
       val a = many1(int)
       val b: Parser[NonEmptyList[Int]] = a
+      b
     }
 
     {
       val c = choice(List[Parser[Int]]())
+      c
     }
 
   }

--- a/modules/tests/src/test/scala/atto/IncrementalTest.scala
+++ b/modules/tests/src/test/scala/atto/IncrementalTest.scala
@@ -2,8 +2,6 @@ package atto
 import Atto._
 
 import org.scalacheck._
-import scalaz._
-import atto.compat.scalaz._
 
 object IncrementalTest extends Properties("Incremental") {
   import Prop._
@@ -11,8 +9,8 @@ object IncrementalTest extends Properties("Incremental") {
   // list of ints chunked arbitrarily
   property("incremental/1") = forAll { (n: Int, ns0: List[Int], c: Char, s: String) =>
     val sep = s + s + s + c
-    !sep.exists(_.isDigit) ==> { 
-      val ns = n :: ns0 ++ ns0 ++ ns0 
+    !sep.exists(_.isDigit) ==> {
+      val ns = n :: ns0 ++ ns0 ++ ns0
       val p = sepBy(int, string(sep))
       val s = ns.mkString(sep)
       val c = s.grouped(1 max (n % s.length).abs).toList
@@ -24,4 +22,3 @@ object IncrementalTest extends Properties("Incremental") {
   }
 
 }
-

--- a/modules/tests/src/test/scala/atto/NumericTest.scala
+++ b/modules/tests/src/test/scala/atto/NumericTest.scala
@@ -2,8 +2,6 @@ package atto
 import Atto._
 
 import org.scalacheck._
-import scalaz.\/._
-import atto.compat.scalaz._
 
 object NumericTest extends Properties("Numeric") {
   import Prop._
@@ -57,4 +55,3 @@ object NumericTest extends Properties("Numeric") {
   }
 
 }
-

--- a/modules/tests/src/test/scala/atto/TextTest.scala
+++ b/modules/tests/src/test/scala/atto/TextTest.scala
@@ -7,7 +7,6 @@ import atto.compat.scalaz._
 
 object TextTest extends Properties("Text") {
   import Prop._
-  import Parser._
 
   property("stringOf") = forAll { (s: String) =>
     stringOf(elem(c => s.exists(_ == c))).parseOnly(s).option == Some(s)


### PR DESCRIPTION
The 0.5.x branch doesn't compile on 2.12.2 due to warnings being triggered, mostly unused imports
This PR fixes that but I removed tut from travis as it seems is not available for 2.12