### PR TITLE
check scalaVersion in a community build friendly way

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,9 +3,8 @@ import ReleaseTransformations._
 
 lazy val compilerFlags = Seq(
   scalacOptions ++= (
-    scalaVersion.value match {
-      case "2.10.6"  |
-           "2.11.11" =>
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n <= 11 =>
         Seq(
           "-feature",
           "-deprecation",
@@ -17,7 +16,7 @@ lazy val compilerFlags = Seq(
           "-Yno-imports",
           "-Ywarn-numeric-widen"
         )
-      case "2.12.3" =>
+      case _ =>
         Seq(
           "-deprecation",                      // Emit warning and location for usages of deprecated APIs.
           "-encoding", "utf-8",                // Specify character encoding used by source files.
@@ -69,10 +68,10 @@ lazy val compilerFlags = Seq(
     }
   ),
   scalacOptions in (Test, compile) --= (
-    scalaVersion.value match {
-      case "2.10.6"  |
-           "2.11.11" => Seq("-Yno-imports")
-      case "2.12.3"  =>
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, n)) if n <= 11 =>
+        Seq("-Yno-imports")
+      case _ =>
         Seq(
           "-Ywarn-unused:privates",
           "-Ywarn-unused:locals",
@@ -82,7 +81,7 @@ lazy val compilerFlags = Seq(
     }
   ),
   scalacOptions in (Compile, console) --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports"),
-  scalacOptions in (Tut, tut)         --=  Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports")
+  scalacOptions in (Tut, tut)         --= Seq("-Xfatal-warnings", "-Ywarn-unused:imports", "-Yno-imports")
 )
 
 lazy val buildSettings = Seq(


### PR DESCRIPTION
this way also works with Scala nightlies, with 2.13.x, etc