### PR TITLE
[WIP] Adds Refined support

### DIFF
--- a/modules/refined/src/main/scala/atto/syntax/ParserRefinedOps.scala
+++ b/modules/refined/src/main/scala/atto/syntax/ParserRefinedOps.scala
@@ -1,0 +1,25 @@
+package atto
+package syntax
+
+import eu.timepit.refined.api.{Refined, Validate}
+import eu.timepit.refined.refineV
+import scala.language.implicitConversions
+
+trait ParserRefinedOps[T] {
+  val self: Parser[T]
+  import atto.parser.combinator.{err, ok}
+
+  def refined[P](implicit ev: Validate[T, P]): Parser[T Refined P] = 
+    self.flatMap(refineV(_).fold(err, ok))
+}
+
+trait ToParserRefinedOps {
+
+  implicit def toParserRefinedOps[T](p: Parser[T]): ParserRefinedOps[T] =
+    new ParserRefinedOps[T] {
+      val self: Parser[T] = p
+    }
+
+}
+
+object refined extends ToParserRefinedOps

--- a/modules/tests/src/test/scala/atto/RefinedTest.scala
+++ b/modules/tests/src/test/scala/atto/RefinedTest.scala
@@ -1,0 +1,20 @@
+package atto
+
+import atto.Atto._
+import atto.syntax.refined._
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.string.MatchesRegex
+import eu.timepit.refined.W
+import cats.implicits._
+import org.scalacheck._
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Any"))
+object RefinedTest extends Properties("Refined") {
+  import Prop._
+
+  property("refined") = forAll { (n: Long) =>
+    type Hex = MatchesRegex[W.`"[0-9a-fA-F]+"`.T]
+    val hexStr = n.toHexString
+    stringOf(hexDigit).refined[Hex].parseOnly(hexStr).option.map(_.value) === Some(hexStr)
+  }
+}

--- a/modules/tests/src/test/scala/atto/RefinedTest.scala
+++ b/modules/tests/src/test/scala/atto/RefinedTest.scala
@@ -2,7 +2,6 @@ package atto
 
 import atto.Atto._
 import atto.syntax.refined._
-import eu.timepit.refined.api.Refined
 import eu.timepit.refined.string.MatchesRegex
 import eu.timepit.refined.W
 import cats.implicits._
@@ -12,9 +11,15 @@ import org.scalacheck._
 object RefinedTest extends Properties("Refined") {
   import Prop._
 
-  property("refined") = forAll { (n: Long) =>
+  property("refined success") = forAll { (n: Long) =>
     type Hex = MatchesRegex[W.`"[0-9a-fA-F]+"`.T]
     val hexStr = n.toHexString
     stringOf(hexDigit).refined[Hex].parseOnly(hexStr).option.map(_.value) === Some(hexStr)
+  }
+
+  property("refined error") = forAll { (n: Long) =>
+    type Alpha = MatchesRegex[W.`"[e-z]+"`.T]
+    stringOf(anyChar).refined[Alpha].parseOnly(n.toString).either.swap.toOption ===
+      Some(s"""Predicate failed: "$n".matches("[e-z]+").""")
   }
 }


### PR DESCRIPTION
Resolves https://github.com/tpolecat/atto/issues/78

  - [x] Implementation 
  - [x] Tests
  - [ ] Docs

Allows developers to create parsers for refined types, for example:
```scala
type Hex8 = MatchesRegex[W.`"[0-9a-fA-F]{8}"`.T]
val hex8: Parser[String Refined Hex8] = stringOf(hexDigit).refined[Hex8]
```