### PR TITLE
Adds Fs2 module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk:
 
 script:
   - sbt ++2.11.12 test
-  - sbt ++2.13.0-M4 tests/test
+  - sbt ++2.13.0-M4 testsJVM/test testsJS/test
   - sbt ++2.12.7  coverage test docs/tut coverageReport
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jdk:
 
 script:
   - sbt ++2.11.12 test
-  - sbt ++2.13.0-M4 test
+  - sbt ++2.13.0-M4 tests/test
   - sbt ++2.12.7  coverage test docs/tut coverageReport
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jdk:
 script:
   - sbt ++2.11.12 test
   - sbt ++2.13.0-M4 testsJVM/test testsJS/test
-  - sbt ++2.12.7  coverage test docs/tut coverageReport
+  - sbt ++2.12.6  coverage test docs/tut coverageReport
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,9 @@ jdk:
   - oraclejdk8
 
 script:
-  - sbt ++2.10.6  test
-  - sbt ++2.11.11 test
+  - sbt ++2.11.12 test
   - sbt ++2.13.0-M4 test
-  - sbt ++2.12.4  coverage test docs/tut coverageReport
+  - sbt ++2.12.7  coverage test docs/tut coverageReport
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val buildSettings = Seq(
 		("MIT", url("http://opensource.org/licenses/MIT")),
 		("BSD New", url("http://opensource.org/licenses/BSD-3-Clause"))
 	),
-	scalaVersion := "2.12.7",
+	scalaVersion := "2.12.6",
 	crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.0-M4"),
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.7" cross CrossVersion.binary)
 )

--- a/build.sbt
+++ b/build.sbt
@@ -2,8 +2,9 @@ import ReleaseTransformations._
 import microsites._
 import sbtcrossproject.{crossProject, CrossType}
 
-lazy val catsVersion = "1.2.0"
+lazy val catsVersion = "1.4.0"
 lazy val refinedVersion = "0.9.2"
+lazy val fs2Version = "1.0.0"
 
 // Only run WartRemover on 2.12
 def attoWarts(sv: String) =
@@ -169,8 +170,8 @@ lazy val noPublishSettings = Seq(
 lazy val atto = project.in(file("."))
   .settings(buildSettings ++ commonSettings)
   .settings(noPublishSettings)
-  .dependsOn(coreJVM, coreJS, refinedJVM, refinedJS, testsJVM, testsJS)
-  .aggregate(coreJVM, coreJS, refinedJVM, refinedJS, testsJVM, testsJS)
+  .dependsOn(coreJVM, coreJS, fs2JVM, fs2JS, refinedJVM, refinedJS, testsJVM, testsJS)
+  .aggregate(coreJVM, coreJS, fs2JVM, fs2JS, refinedJVM, refinedJS, testsJVM, testsJS)
   .settings(
     releaseCrossBuild := true,
     releaseProcess := Seq[ReleaseStep](
@@ -198,6 +199,14 @@ lazy val core = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).
 
 lazy val coreJVM = core.jvm
 lazy val coreJS = core.js
+
+lazy val fs2 = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("modules/fs2"))
+  .settings(buildSettings ++ commonSettings ++ publishSettings)
+  .settings(name := "atto-fs2")
+	.settings(libraryDependencies += "co.fs2" %%% "fs2-core" % fs2Version)
+
+lazy val fs2JVM = fs2.jvm
+lazy val fs2JS = fs2.js
 
 lazy val refined = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("modules/refined"))
   .dependsOn(core)

--- a/build.sbt
+++ b/build.sbt
@@ -127,7 +127,7 @@ lazy val buildSettings = Seq(
 		("MIT", url("http://opensource.org/licenses/MIT")),
 		("BSD New", url("http://opensource.org/licenses/BSD-3-Clause"))
 	),
-	scalaVersion := "2.12.5",
+	scalaVersion := "2.12.7",
 	crossScalaVersions := Seq("2.10.6", "2.11.12", scalaVersion.value, "2.13.0-M4"),
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.7" cross CrossVersion.binary)
 )
@@ -207,6 +207,7 @@ lazy val fs2 = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).i
   .dependsOn(core)
   .settings(name := "atto-fs2")
 	.settings(libraryDependencies += "co.fs2" %%% "fs2-core" % fs2Version)
+  .settings(crossScalaVersions := Seq("2.10.6", "2.11.12", scalaVersion.value))
 
 lazy val fs2JVM = fs2.jvm
 lazy val fs2JS = fs2.js

--- a/build.sbt
+++ b/build.sbt
@@ -85,6 +85,7 @@ lazy val compilerFlags = Seq(
           "-Xlint:type-parameter-shadow",      // A local type parameter shadows a type already in scope.
           "-Xlint:unsound-match",              // Pattern match may not be typesafe.
           "-Yno-imports",                      // No predef or default imports
+          "-Yrangepos",                        // Report Range Position of Errors to Language Server
           "-Ywarn-dead-code",                  // Warn when dead code is identified.
           "-Ywarn-extra-implicit",             // Warn when more than one implicit parameter section is defined.
           "-Ywarn-inaccessible",               // Warn about inaccessible types in method signatures.
@@ -99,6 +100,7 @@ lazy val compilerFlags = Seq(
           "-Ywarn-unused:patvars",             // Warn if a variable bound in a pattern is unused.
           "-Ywarn-unused:privates",            // Warn if a private member is unused.
           "-Ywarn-value-discard"               // Warn when non-Unit expression results are unused.
+
         )
     }
   ),
@@ -202,6 +204,7 @@ lazy val coreJS = core.js
 
 lazy val fs2 = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("modules/fs2"))
   .settings(buildSettings ++ commonSettings ++ publishSettings)
+  .dependsOn(core)
   .settings(name := "atto-fs2")
 	.settings(libraryDependencies += "co.fs2" %%% "fs2-core" % fs2Version)
 

--- a/build.sbt
+++ b/build.sbt
@@ -128,7 +128,7 @@ lazy val buildSettings = Seq(
 		("BSD New", url("http://opensource.org/licenses/BSD-3-Clause"))
 	),
 	scalaVersion := "2.12.7",
-	crossScalaVersions := Seq("2.10.6", "2.11.12", scalaVersion.value, "2.13.0-M4"),
+	crossScalaVersions := Seq("2.11.12", scalaVersion.value, "2.13.0-M4"),
   addCompilerPlugin("org.spire-math" % "kind-projector" % "0.9.7" cross CrossVersion.binary)
 )
 
@@ -207,7 +207,7 @@ lazy val fs2 = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).i
   .dependsOn(core)
   .settings(name := "atto-fs2")
 	.settings(libraryDependencies += "co.fs2" %%% "fs2-core" % fs2Version)
-  .settings(crossScalaVersions := Seq("2.10.6", "2.11.12", scalaVersion.value))
+  .settings(crossScalaVersions := Seq("2.11.12", scalaVersion.value))
 
 lazy val fs2JVM = fs2.jvm
 lazy val fs2JS = fs2.js

--- a/build.sbt
+++ b/build.sbt
@@ -5,6 +5,7 @@ import sbtcrossproject.{crossProject, CrossType}
 lazy val catsVersion = "1.4.0"
 lazy val refinedVersion = "0.9.2"
 lazy val fs2Version = "1.0.0"
+lazy val scalacheckVersion = "1.14.0"
 
 // Only run WartRemover on 2.12
 def attoWarts(sv: String) =
@@ -207,6 +208,7 @@ lazy val fs2 = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).i
   .dependsOn(core)
   .settings(name := "atto-fs2")
 	.settings(libraryDependencies += "co.fs2" %%% "fs2-core" % fs2Version)
+  .settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % Test)
   .settings(crossScalaVersions := Seq("2.11.12", scalaVersion.value))
 
 lazy val fs2JVM = fs2.jvm
@@ -224,7 +226,7 @@ lazy val refinedJS = refined.js
 lazy val tests = crossProject(JSPlatform, JVMPlatform).crossType(CrossType.Pure).in(file("modules/tests"))
 	.dependsOn(core, refined)
   .settings(buildSettings ++ commonSettings ++ noPublishSettings)
-	.settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % "1.14.0" % "test")
+	.settings(libraryDependencies += "org.scalacheck" %%% "scalacheck" % scalacheckVersion % Test)
   .settings(name := "atto-tests")
 
 lazy val testsJVM = tests.jvm

--- a/modules/fs2/src/main/scala/atto/fs2/Pipes.scala
+++ b/modules/fs2/src/main/scala/atto/fs2/Pipes.scala
@@ -24,7 +24,9 @@ object Pipes {
             // Add String To Result If Stream Has More Values
             case Some((s, rest)) => go(r.feed(s))(rest)
             // Reached Stream Termination and Still Partial - Return the partial
-            case None => Pull.output1(r)
+            // If we do not call done here, if this can still accept input it will
+            // be a partial rather than a done.
+            case None => Pull.output1(r.done)
           }
         case _ => Pull.output1(r)
       }

--- a/modules/fs2/src/main/scala/atto/fs2/Pipes.scala
+++ b/modules/fs2/src/main/scala/atto/fs2/Pipes.scala
@@ -4,9 +4,10 @@ import atto._
 import atto.Atto._
 import atto.ParseResult._
 
-import java.lang.String
+import java.lang.{String, SuppressWarnings}
 import scala.{Some, None, Unit}
-// import scala.{ List, Nil }
+import scala.{ List, Nil, Array }
+import scala.Predef.{ augmentString }
 import scala.language._
 
 import _root_.fs2._
@@ -14,6 +15,7 @@ import _root_.fs2._
 object Pipes {
 
   /** Parse a stream and return a single terminal ParseResult. */
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion", "org.wartremover.warts.Any"))
   def parse1[F[_], A](p: Parser[A]): Pipe[F, String, ParseResult[A]] = s => {
     def go(r: ParseResult[A])(s: Stream[F, String]): Pull[F, ParseResult[A], Unit] = {
       r match {
@@ -30,5 +32,56 @@ object Pipes {
     go(p.parse(""))(s).stream
   }
 
+  /** Parse a stream into a series of values, halting on invalid input. */
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion", "org.wartremover.warts.Any"))
+  def parseN[F[_], A](p: Parser[A]): Pipe[F, String, A] = s => {
+    def exhaust(r: ParseResult[A], acc: List[A]): (ParseResult[A], List[A]) =
+      r match {
+        case Done(in, a) => exhaust(p.parse(in), a :: acc) 
+        case _           => (r, acc)
+      }
+
+    def go(r: ParseResult[A])(s: Stream[F, String]): Pull[F, A, Unit] = {
+      s.pull.uncons1.flatMap{
+        case Some((s, rest)) =>
+          val (r0, acc) = r match {
+            case Done(in, a)    => (p.parse(in + s), List(a)) 
+            case Fail(_, _, _) => (r, Nil)
+            case Partial(_)     => (r.feed(s), Nil)
+          }
+          val (r1, as) = exhaust(r0, acc)
+          Pull.output(Chunk.seq(as.reverse)) >> go(r1)(rest)
+        case None => Pull.output(Chunk.seq(exhaust(r.done, Nil)._2))
+      }
+    }
+
+    go(p.parse(""))(s).stream
+  }
+
+  /** Parse a stream into a series of values, discarding invalid input. */
+  @SuppressWarnings(Array("org.wartremover.warts.Recursion", "org.wartremover.warts.Any"))
+  def parseLenient[F[_], A](p: Parser[A]): Pipe[F, String, A] = s => {
+    def exhaust(r: ParseResult[A], acc: List[A]): (ParseResult[A], List[A]) =
+      r match {
+        case Done(in, a)    => exhaust(p.parse(in), a :: acc) 
+        case Fail(in, _, _) => exhaust(p.parse(in.drop(1)), acc)
+        case Partial(_)     => (r, acc)
+      }
+
+    def go(r: ParseResult[A])(s: Stream[F, String]): Pull[F, A, Unit] = {
+      s.pull.uncons1.flatMap{
+        case Some((s, rest)) =>
+          val (r0, acc) = r match {
+            case Done(in, a)    => (p.parse(in + s), List(a)) 
+            case Fail(in, _, _) => (p.parse(in.drop(1) + s), Nil)
+            case Partial(_)     => (r.feed(s), Nil)
+          }
+          val (r1, as) = exhaust(r0, acc)
+          Pull.output(Chunk.seq(as.reverse)) >> go(r1)(rest)
+        case None => Pull.output(Chunk.seq(exhaust(r.done, Nil)._2))
+      }
+    }
+    go(p.parse(""))(s).stream
+  }
 
 }

--- a/modules/fs2/src/main/scala/atto/fs2/Pipes.scala
+++ b/modules/fs2/src/main/scala/atto/fs2/Pipes.scala
@@ -1,0 +1,34 @@
+package atto.fs2
+
+import atto._
+import atto.Atto._
+import atto.ParseResult._
+
+import java.lang.String
+import scala.{Some, None, Unit}
+// import scala.{ List, Nil }
+import scala.language._
+
+import _root_.fs2._
+
+object Pipes {
+
+  /** Parse a stream and return a single terminal ParseResult. */
+  def parse1[F[_], A](p: Parser[A]): Pipe[F, String, ParseResult[A]] = s => {
+    def go(r: ParseResult[A])(s: Stream[F, String]): Pull[F, ParseResult[A], Unit] = {
+      r match {
+        case Partial(_) => 
+          s.pull.uncons1.flatMap{
+            // Add String To Result If Stream Has More Values
+            case Some((s, rest)) => go(r.feed(s))(rest)
+            // Reached Stream Termination and Still Partial - Return the partial
+            case None => Pull.output1(r)
+          }
+        case _ => Pull.output1(r)
+      }
+    }
+    go(p.parse(""))(s).stream
+  }
+
+
+}

--- a/modules/fs2/src/test/scala/atto/fs2/PipesTest.scala
+++ b/modules/fs2/src/test/scala/atto/fs2/PipesTest.scala
@@ -1,0 +1,74 @@
+package atto.fs2
+
+import atto._
+import Atto._
+import cats._
+import cats.implicits._
+import _root_.fs2._
+
+import org.scalacheck._
+
+@SuppressWarnings(Array("org.wartremover.warts.NonUnitStatements", "org.wartremover.warts.Any"))
+object Fs2PipesTest extends Properties("Pipes") {
+  import Prop._
+
+  property("parse1 parses single value correctly") = forAll(Gen.posNum[Int]) { i: Int => 
+    {
+      val test = Stream.emit(i.show)
+        .through(Pipes.parse1[Pure, Int](int))
+        .compile
+        .last
+        .toRight("Nothing Emited")
+        .flatMap(_.either)
+      val expected = Either.right(i)
+      test === expected
+    }
+  }
+
+  property("parse1 outputs a failed parser on invalid input") = forAll(Gen.alphaStr) { s: String => 
+    {
+      val test = Stream.emit(s)
+        .through(Pipes.parse1[Pure, Int](int))
+        .compile
+        .last
+        .toRight("Nothing Emited")
+        .flatMap(_.either)
+      val expected = Either.left("Failure reading:bigInt")
+      test === expected
+    }
+  }
+
+  property("parseN outputs all values if good") = forAll(Gen.listOf(Gen.choose(0, 9))) {l : List[Int] => 
+    val test = Stream.emits(l.map(_.show))
+        .through(Pipes.parseN[Pure, Int](take(1).map(_.toInt))) //Known to be safe due to Gen used
+        .toList
+    
+    test === l
+  }
+
+  property("parseN outputs values up until and Error") = forAll(Gen.listOf(Gen.choose(0, 9))) {l : List[Int] => 
+    val listStrings = l match {
+      case h :: hs => h.show :: " " :: hs.map(_.show)
+      case Nil => List.empty[String]
+    }
+    val test = Stream.emits(listStrings)
+        .through(Pipes.parseN[Pure, Int](int))
+        .toList
+        .headOption
+    
+    test === l.headOption
+  }
+
+  property("parseLenient recreates initial list on appropriate parser") = forAll { l: List[Int] =>
+    val listStrings : List[String] = l.map(_.show)
+    val stringStream: Stream[Pure, String] = Stream.emits(listStrings).intersperse(" ")
+    stringStream.through(Pipes.parseLenient[Pure, Int](int)).toList === l
+  }
+
+  property("parseLenient ignoresInvalid") = forAll(Gen.alphaStr, Arbitrary.arbitrary[List[Int]]) { (s: String, l: List[Int]) => 
+    val listStrings : List[String] = l.map(_.show)
+    val stringStream: Stream[Pure, String] = Stream.emit(s) ++ Stream.emits(listStrings).intersperse(" ")
+    stringStream.through(Pipes.parseLenient[Pure, Int](int)).toList === l
+  }
+
+}


### PR DESCRIPTION
Keeps Consistent Semantics with [Scalaz-Stream](https://github.com/tpolecat/atto/blob/v0.4.2/stream/src/main/scala/atto/stream/Stream.scala) implementation.

There may be some major improvements if we use chunks rather than uncons1 and the newer mechanics available in fs2. But this gets it operational.

Would you like the implicit syntax classes brought back? 