### PR TITLE
Update cats to 1.5.0 and fs2 to 1.0.2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,9 +2,9 @@ import ReleaseTransformations._
 import microsites._
 import sbtcrossproject.{crossProject, CrossType}
 
-lazy val catsVersion = "1.4.0"
+lazy val catsVersion = "1.5.0"
 lazy val refinedVersion = "0.9.2"
-lazy val fs2Version = "1.0.0"
+lazy val fs2Version = "1.0.2"
 lazy val scalacheckVersion = "1.14.0"
 
 // Only run WartRemover on 2.12


### PR DESCRIPTION
There is a minor binary incompatibility, doesn't look like its because of this change
```
[warn] 	* org.scala-lang.modules:scala-xml_2.12:1.1.0 is selected over 1.0.6
[warn] 	    +- eu.timepit:refined_2.12:0.9.2 ()                   (depends on 1.1.0)
[warn] 	    +- eu.timepit:refined_sjs0.6_2.12:0.9.2 ()            (depends on 1.1.0)
[warn] 	    +- org.scala-lang:scala-compiler:2.12.6               (depends on 1.0.6)
```