### PR TITLE
Implemented withFilter to support guards in for comprehensions

### DIFF
--- a/modules/core/src/main/scala/atto/Parser.scala
+++ b/modules/core/src/main/scala/atto/Parser.scala
@@ -32,6 +32,8 @@ trait Parser[+A] { m =>
   def filter(p: A => Boolean): Parser[A] =
     parser.combinator.filter(this)(p)
 
+  def withFilter(p: A => Boolean): Parser[A] = filter(p)
+
   def void: Parser[Unit] =
     this.map(_ => ())
 

--- a/modules/tests/src/test/scala/atto/CombinatorTest.scala
+++ b/modules/tests/src/test/scala/atto/CombinatorTest.scala
@@ -247,6 +247,12 @@ object CombinatorTest extends Properties("Combinator") {
       Some(c).filter(_.isLetterOrDigit)
   }
 
+  property("for-comprehension/guard") = forAll { (c: Char) =>
+    (for {
+      c <- anyChar if c.isLetterOrDigit
+    } yield c).parseOnly(c.toString).option === Some(c).filter(_.isLetterOrDigit)
+  }
+
   property("count") = forAll { (c: Char, n0: Int) =>
     val n = (n0.abs % 10) + 1
     val s = c.toString * 20


### PR DESCRIPTION
With this pull request we can use `if` in a `for` comprehension on parsers:

```scala
val letterOrDigitParser = for {
  c <- anyChar if c.isLetterOrDigit
} yield c
```