### PR TITLE
Improved test coverage on Character.scala and made minor changes

### DIFF
--- a/modules/core/src/main/scala/atto/parser/Character.scala
+++ b/modules/core/src/main/scala/atto/parser/Character.scala
@@ -42,12 +42,8 @@ trait Character {
     satisfy(_ =!= c) named ("not '" + c.toString + "'")
 
   /** Decimal digit, 0-9. */
-  def digit: Parser[Char] =
-    elem(_.isDigit, "digit")
-
-  /** Decimal digit, 0-9. */
   def decimalDigit: Parser[Char] =
-    digit
+    charRange('0' to '9') named "decimalDigit"
 
   /** Hex digit, 0-9, A-F, a-f */
   def hexDigit: Parser[Char] =
@@ -64,6 +60,13 @@ trait Character {
   def octalDigit: Parser[Char] =
     charRange('0' to '7')
 
+  /** The following parsers have been derived from Character.java.
+   *  Note that they also handle non-Western unicode characters.
+   *  See Java documentation for details. */
+
+  def digit: Parser[Char] =
+    elem(_.isDigit, "digit")
+
   def letter: Parser[Char] =
     elem(_.isLetter, "letter")
 
@@ -78,6 +81,9 @@ trait Character {
 
   def upper: Parser[Char] =
     elem(_.isUpper, "upper")
+
+  def whitespace: Parser[Char] =
+    elem(c => c.isWhitespace, "whitespace")
 
   type CharRange = scala.collection.immutable.NumericRange[Char]
 
@@ -94,11 +100,7 @@ trait Character {
   def skip(p: Char => Boolean): Parser[Unit] =
     elem(p).void named "skip(...)"
 
-  /** Horizontal or vertical whitespace character */
-  def whitespace: Parser[Char] =
-    elem(c => c.isWhitespace, "whitespace")
-
   /** Whitespace that is not a line break */
   def horizontalWhitespace: Parser[Char] =
-    elem(c => c.isWhitespace && c =!= '\r' && c =!= '\n', "horizontalWhitespace")
+    oneOf(" \t") named "horizontalWhitespace"
 }

--- a/modules/tests/src/test/scala/atto/CharacterTest.scala
+++ b/modules/tests/src/test/scala/atto/CharacterTest.scala
@@ -58,4 +58,44 @@ object CharacterTest extends Properties("Character") {
     p.parseOnly(s).option === Some(s.toList.takeWhile(_ < c))
   }
 
+  property("decimalDigit") = forAll { (c: Char) =>
+    decimalDigit.parseOnly(c.toString).option ===
+      (if("0123456789".contains(c)) Some(c) else None)
+  }
+
+  property("binaryDigit") = forAll { (c: Char) =>
+    binaryDigit.parseOnly(c.toString).option ===
+      (if(c == '0' || c == '1') Some(c) else None)
+  }
+
+  property("octalDigit") = forAll { (c: Char) =>
+    octalDigit.parseOnly(c.toString).option ===
+      (if("01234567".contains(c)) Some(c) else None)
+  }
+
+  property("Character.java derivatives") = forAll { (c: Char) =>
+    List[(Parser[Char], Function[Char, Boolean])](
+      (digit, _.isDigit),
+      (letter, _.isLetter),
+      (letterOrDigit, _.isLetterOrDigit),
+      (lower, _.isLower),
+      (spaceChar, _.isSpaceChar),
+      (upper, _.isUpper),
+      (whitespace, _.isWhitespace)).map {
+      case (parser, predicate) =>
+        parser.parseOnly(c.toString).option ===
+          (if (predicate(c)) Some(c) else None)
+    }.forall(_ == true)
+  }
+
+  property("skip") = forAll { (c: Char, b: Boolean) =>
+    val predicate = (cc: Char) => if(b) c == cc else c != cc
+    skip(predicate).parseOnly(c.toString).option ===
+      (if (predicate(c)) Some(()) else None)
+  }
+
+  property("horizontalWhitespace") = forAll { (c: Char) =>
+    horizontalWhitespace.parseOnly(c.toString).option ===
+      (if (c == ' ' || c == '\t') Some(c) else None)
+  }
 }


### PR DESCRIPTION
The tests cover all parsing functionality in Character.scala (only the lazy evaluation of `named` clauses is not covered).

During property based testing, I found that relying on the Character.java implementation of some functions was not intuitive, so I changed the implementation of `decimalDigit` (it previously also parsed Arabic numbers) and `horizontalWhitespace` (it previously also parsed unit feed, for example).